### PR TITLE
Fixed bug when scrollFrame doesn't start at 0, 0

### DIFF
--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -135,17 +135,17 @@ class exports.LayerDraggable extends BaseClass
 			layerHeightTooSmall = @layer.height < value.height
 
 			if layerWidthTooSmall
-				x = 0
+				x = value.x
 				width = @layer.width
 			else
-				x = - @layer.width + value.width
+				x = value.x - @layer.width + value.width
 				width = @layer.width * 2 - value.width
 
 			if layerHeightTooSmall
-				y = 0
+				y = value.y
 				height = @layer.height
 			else
-				y = - @layer.height + value.height
+				y = value.y - @layer.height + value.height
 				height = @layer.height * 2 - value.height
 
 			@maxDragFrame = {x, y, width, height}


### PR DESCRIPTION
I had this weird bug where my layers (at x=750) would keep flying to the left of the screen :) Seems like the scroll frame doesn't take into account cases where the y-scrollable layer sits at x=750 (I'm doing a sideways paging view where each layer scrolls vertically) 

@dabbott  
